### PR TITLE
Bug managing zip files resolved

### DIFF
--- a/play.php
+++ b/play.php
@@ -34,7 +34,7 @@
 		{
 			$names =$zip->getNameIndex(0);
 			$ext0 = explode(".", $names);
-			$ext = strtolower(end($ext));
+			$ext = strtolower(end($ext0));
 		}
             }
 


### PR DESCRIPTION
Opening roms in zip files wasn't working, and I saw that the used variable in line 37 should be ext0 (the extension of the file inside the zip declared in line 36) instead of ext (in this case, zip).